### PR TITLE
add a bool to update test goldens

### DIFF
--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -4,10 +4,14 @@ import * as ts from 'typescript';
 import {expect} from 'chai';
 
 import {annotateProgram, formatDiagnostics} from '../src/sickle';
-import {expectSource, goldenTests} from './test_support';
+import {sickleSource, goldenTests} from './test_support';
 
 let RUN_TESTS_MATCHING: RegExp = null;
 // RUN_TESTS_MATCHING = /fields/;
+
+// If true, update all the golden .js files to be whatever sickle
+// produces from the .ts source.
+let UPDATE_GOLDENS = false;
 
 describe('golden tests', () => {
 
@@ -18,6 +22,12 @@ describe('golden tests', () => {
     }
     var tsSource = fs.readFileSync(test.tsPath, 'utf-8');
     var jsSource = fs.readFileSync(test.jsPath, 'utf-8');
-    it(test.name, () => { expectSource(tsSource).to.equal(jsSource); });
+    it(test.name, () => {
+      let sickleJs = sickleSource(tsSource);
+      if (UPDATE_GOLDENS && sickleJs != jsSource) {
+        fs.writeFileSync(test.jsPath, sickleJs, 'utf-8');
+      }
+      expect(sickleJs).to.equal(jsSource);
+    });
   });
 });

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -72,11 +72,11 @@ function transformSource(src: string): string {
   return transformed['main.js'];
 }
 
-export function expectSource(src: string) {
+export function sickleSource(src: string): string {
   var annotated = annotateSource(src);
   // console.log('Annotated:\n', annotated);
   var transformed = transformSource(annotated);
-  return expect(transformed);
+  return transformed;
 }
 
 export interface GoldenFileTest {


### PR DESCRIPTION
When (manually) flipped to true, running the test rewrites all
the golden files such that the test passes.  Use this to update
the goldens after you've made a sickle change (and review the
new golden outputs carefully!).