### PR TITLE
Change Sickle main entry point to ts.SourceFile

### DIFF
--- a/test/e2e_test.ts
+++ b/test/e2e_test.ts
@@ -4,7 +4,6 @@ import * as ts from 'typescript';
 import {expect} from 'chai';
 import {CompileOptions, compile} from 'closure-compiler';
 
-import {annotateProgram, formatDiagnostics} from '../src/sickle';
 import {goldenTests} from './test_support';
 
 export function checkClosureCompile(jsFiles: string[], done: (err: Error) => void) {

--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import * as ts from 'typescript';
 import {expect} from 'chai';
 
-import {annotateProgram, formatDiagnostics} from '../src/sickle';
 import {sickleSource, goldenTests} from './test_support';
 
 let RUN_TESTS_MATCHING: RegExp = null;

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -3,7 +3,7 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 
-import {annotateProgram, formatDiagnostics, StringMap} from '../src/sickle';
+import {annotate, formatDiagnostics} from '../src/sickle';
 
 const OPTIONS: ts.CompilerOptions = {
   target: ts.ScriptTarget.ES6,
@@ -37,9 +37,7 @@ function annotateSource(src: string): string {
     throw new Error(formatDiagnostics(ts.getPreEmitDiagnostics(program)));
   }
 
-  var res = annotateProgram(program);
-  expect(Object.keys(res)).to.deep.equal(['main.ts']);
-  return res['main.ts'];
+  return annotate(program.getSourceFile('main.ts'));
 }
 
 function transformSource(src: string): string {
@@ -62,7 +60,7 @@ function transformSource(src: string): string {
         'Failed to parse ' + src + '\n' + formatDiagnostics(ts.getPreEmitDiagnostics(program)));
   }
 
-  var transformed: StringMap = {};
+  var transformed: {[fileName: string]: string} = {};
   var emitRes =
       program.emit(mainSrc, (fileName: string, data: string) => { transformed[fileName] = data; });
   if (emitRes.diagnostics.length) {


### PR DESCRIPTION
ts.Program (the previous parameter) is a fully compiled program of
potentially multiple files, while ts.SourceFile is a single parsed file.
It appears from how we're using sickle that we want the latter, not the
former.

(It may be the case that we need a fully compiled program to get all the
references right, but for now this appears to work.)