### PR TITLE
keep existing closure annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ typings
 
 # Dependency directory
 node_modules
+
+# WebStorm/IntelliJ directory
+.idea
+
+# VSCode directory
+.vscode

--- a/test_files/comments.js
+++ b/test_files/comments.js
@@ -1,0 +1,12 @@
+class A {
+    constructor() {
+        // Sickle: begin stub declarations.
+        /**  @export @type { string} */
+        this.foo;
+        /** @type { number} */
+        this.bar;
+        /** @type { number} */
+        this.buz;
+        // Sickle: end stub declarations.
+    }
+}

--- a/test_files/comments.ts
+++ b/test_files/comments.ts
@@ -1,0 +1,8 @@
+class A {
+  /** @export */
+  foo: string;
+  /* non js-doc comment */
+  bar: number;
+  // non js-doc comment
+  buz: number;
+}


### PR DESCRIPTION
Certain closure annotations have not equivalent in TS, especially the
ones concerned with minification, not type-checking (like @export). The
authors of the code will have to write them in TS and sickle should perserve
them.

Closes #12 