### PR TITLE
use full file text for grabbing substrings from offsets

### DIFF
--- a/test_files/file_comment.js
+++ b/test_files/file_comment.js
@@ -1,0 +1,5 @@
+/** @return { string} */ // This test verifies that initial comments don't confuse offsets.
+function foo() {
+    return 'foo';
+}
+// More text here to exhibit the problem.

--- a/test_files/file_comment.ts
+++ b/test_files/file_comment.ts
@@ -1,0 +1,5 @@
+// This test verifies that initial comments don't confuse offsets.
+function foo(): string {
+  return 'foo';
+}
+// More text here to exhibit the problem.


### PR DESCRIPTION
When a node has a file-relative offset index, you must use the file's
full text (this.file.text / this.file.getFullText()) and not the file's
text with initial comments removed (this.file.getText()).