### PR TITLE
add an option to disable all type translation

### DIFF
--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as ts from 'typescript';
 import {expect} from 'chai';
 
+import {SickleOptions} from '../src/sickle';
 import {sickleSource, goldenTests} from './test_support';
 
 let RUN_TESTS_MATCHING: RegExp = null;
@@ -19,10 +20,14 @@ describe('golden tests', () => {
       it.skip(test.name);
       return;
     }
+    let options: SickleOptions = {};
+    if (/\.untyped\./.test(test.name)) {
+      options.untyped = true;
+    }
     var tsSource = fs.readFileSync(test.tsPath, 'utf-8');
     var jsSource = fs.readFileSync(test.jsPath, 'utf-8');
     it(test.name, () => {
-      let sickleJs = sickleSource(tsSource);
+      let sickleJs = sickleSource(tsSource, options);
       if (UPDATE_GOLDENS && sickleJs != jsSource) {
         console.log('Updating golden file for', test.jsPath);
         fs.writeFileSync(test.jsPath, sickleJs, 'utf-8');

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -3,6 +3,7 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 
+import {SickleOptions} from '../src/sickle';
 import {annotate, formatDiagnostics} from '../src/sickle';
 
 const OPTIONS: ts.CompilerOptions = {
@@ -19,7 +20,7 @@ const {cachedLibPath, cachedLib} = (function() {
   return {cachedLibPath: p, cachedLib: host.getSourceFile(fn, ts.ScriptTarget.ES6)};
 })();
 
-function annotateSource(src: string): string {
+function annotateSource(src: string, options: SickleOptions = {}): string {
   var host = ts.createCompilerHost(OPTIONS);
   var original = host.getSourceFile.bind(host);
   host.getSourceFile = function(
@@ -37,7 +38,7 @@ function annotateSource(src: string): string {
     throw new Error(formatDiagnostics(ts.getPreEmitDiagnostics(program)));
   }
 
-  return annotate(program.getSourceFile('main.ts'));
+  return annotate(program.getSourceFile('main.ts'), options);
 }
 
 function transformSource(src: string): string {
@@ -70,8 +71,8 @@ function transformSource(src: string): string {
   return transformed['main.js'];
 }
 
-export function sickleSource(src: string): string {
-  var annotated = annotateSource(src);
+export function sickleSource(src: string, options: SickleOptions = {}): string {
+  var annotated = annotateSource(src, options);
   // console.log('Annotated:\n', annotated);
   var transformed = transformSource(annotated);
   return transformed;

--- a/test_files/basic.untyped.js
+++ b/test_files/basic.untyped.js
@@ -1,0 +1,17 @@
+/** @return { ?} */ // This test is just a random collection of typed code, to
+// ensure the output is all with {?} annotations.
+function func(/** ? */ arg1) {
+    return [3];
+}
+class Foo {
+    constructor(ctorArg) {
+        // Sickle: begin stub declarations.
+        this.ctorArg = ctorArg;
+        /** @type { ?} */
+        this.field;
+        /** @type { ?} */
+        this.ctorArg;
+        // Sickle: end stub declarations.
+        this.field = 'hello';
+    }
+}

--- a/test_files/basic.untyped.ts
+++ b/test_files/basic.untyped.ts
@@ -1,0 +1,13 @@
+// This test is just a random collection of typed code, to
+// ensure the output is all with {?} annotations.
+function func(arg1: string): number[] {
+  return [3];
+}
+
+class Foo {
+  field: string;
+
+  constructor(private ctorArg: string) {
+    this.field = 'hello';
+  }
+}


### PR DESCRIPTION
This causes types to be translated as {?}, causing the Closure
compiler to not check them.  This is not as awful as it might
seem at first because we believe the TypeScript compiler already
has checked the types.