### PR TITLE
preserve type decls when emitting

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -138,6 +138,7 @@ class Annotator {
         break;
       case ts.SyntaxKind.TypeAliasDeclaration:
         this.visitTypeAlias(<ts.TypeAliasDeclaration>node);
+        this.writeNode(node);
         break;
       default:
         this.writeNode(node);
@@ -212,12 +213,13 @@ class Annotator {
 
   private visitTypeAlias(node: ts.TypeAliasDeclaration) {
     if (this.options.untyped) return;
+    // Write a Closure typedef, which involves an unused "var" declaration.
     this.emit('/** @typedef {');
     this.visit(node.type);
     this.emit('} */\n');
     this.emit('var ');
     this.emit(node.name.getText());
-    this.emit(';\n');
+    this.emit(': void;\n');
   }
 
   private writeNode(node: ts.Node, skipComments: boolean = false) {

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -11,6 +11,7 @@ const OPTIONS: ts.CompilerOptions = {
   noImplicitAny: true,
   noResolve: true,
   skipDefaultLibCheck: true,
+  noEmitOnError: true,
 };
 
 const {cachedLibPath, cachedLib} = (function() {
@@ -56,9 +57,9 @@ function transformSource(src: string): string {
   };
 
   var program = ts.createProgram(['main.ts'], OPTIONS, host);
-  if (program.getSyntacticDiagnostics().length) {
-    throw new Error(
-        'Failed to parse ' + src + '\n' + formatDiagnostics(ts.getPreEmitDiagnostics(program)));
+  let diagnostics = ts.getPreEmitDiagnostics(program);
+  if (diagnostics.length) {
+    throw new Error('Failed to parse ' + src + '\n' + formatDiagnostics(diagnostics));
   }
 
   var transformed: {[fileName: string]: string} = {};


### PR DESCRIPTION
Sickle is supposed to emit the same source with extra Closure bits.
This code previously stripped all type declarations.

Because the tests test the behavior including ES5 generation, it's
hard to make this show up in a test (because types are stripped in
ES5 output).  I verified manually (by logging the intermediate state)
that this is doing the right thing.