### PR TITLE
transpose the indent/log statement in visit()

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -49,8 +49,8 @@ class Annotator {
   }
 
   private visit(node: ts.Node) {
-    this.indent++;
     // this.logWithIndent('node: ' + (<any>ts).SyntaxKind[node.kind]);
+    this.indent++;
     switch (node.kind) {
       case ts.SyntaxKind.VariableDeclaration:
         this.maybeVisitType((<ts.VariableDeclaration>node).type);


### PR DESCRIPTION
This changes the debug output such that the node being visited
looks like the "root" of the tree of logging statements underneath it.

E.g. before this change it would look like

```
  | node: SourceFile   <- the node we're currently visiting
  | log statement here <- logging statement during the body of visit()
  | | node: Child node  <- now entering a child
  | | child log statement  <- within the child's visit()
```

and after

```
  node: SourceFile
  | log statement here
  | node: Child node
  | | child log statement
```