### PR TITLE
don't mangle decorators on processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "source-map": "^0.4.2",
     "source-map-support": "^0.3.1",
-    "typescript": "^1.6.2"
+    "typescript": "^1.8.0"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -222,7 +222,19 @@ class Annotator {
   private writeNode(node: ts.Node, skipComments: boolean = false) {
     if (node.getChildCount() == 0) {
       // Directly write complete tokens.
-      this.emit(skipComments ? node.getText() : node.getFullText());
+      if (skipComments) {
+        // To skip comments, we skip all whitespace/comments preceding
+        // the node.  But if there was anything skipped we should emit
+        // a newline in its place so that the node remains separated
+        // from the previous node.  TODO: don't skip anything here if
+        // there wasn't any comment.
+        if (node.getFullStart() < node.getStart()) {
+          this.emit('\n');
+        }
+        this.emit(node.getText());
+      } else {
+        this.emit(node.getFullText());
+      }
       return;
     }
     if (skipComments) {

--- a/test/test_support.ts
+++ b/test/test_support.ts
@@ -12,6 +12,8 @@ const OPTIONS: ts.CompilerOptions = {
   noResolve: true,
   skipDefaultLibCheck: true,
   noEmitOnError: true,
+  experimentalDecorators: true,
+  emitDecoratorMetadata: true,
 };
 
 const {cachedLibPath, cachedLib} = (function() {

--- a/test_files/decorator.ts
+++ b/test_files/decorator.ts
@@ -1,0 +1,6 @@
+function decorator(a: Object, b: string) {}
+
+class DecoratorTest {
+  @decorator
+  private x: number;
+}

--- a/test_files/es6/decorator.js
+++ b/test_files/es6/decorator.js
@@ -1,0 +1,22 @@
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+function decorator(/** Object */ a, /** string */ b) { }
+class DecoratorTest {
+    constructor() {
+        // Sickle: begin stub declarations.
+        /** @type { number} */
+        this.x;
+        // Sickle: end stub declarations.
+    }
+}
+__decorate([
+    decorator, 
+    __metadata('design:type', Number)
+], DecoratorTest.prototype, "x", void 0);

--- a/test_files/sickle/decorator.ts
+++ b/test_files/sickle/decorator.ts
@@ -1,0 +1,15 @@
+function decorator( /** Object */a: Object, /** string */ b: string) {}
+
+class DecoratorTest {
+  @decorator
+  private x: number;constructor() {
+
+
+// Sickle: begin stub declarations.
+
+ /** @type { number} */
+this.x;
+// Sickle: end stub declarations.
+}
+
+}

--- a/test_files/sickle/parameter_properties.ts
+++ b/test_files/sickle/parameter_properties.ts
@@ -1,6 +1,8 @@
 class ParamProps {
   // The @export below should not show up in the output ctor.
-  constructor(public bar: string,public bar2: string) {
+  constructor(
+public bar: string,
+public bar2: string) {
 
 // Sickle: begin stub declarations.
 


### PR DESCRIPTION
There were two issues:
1) TypeScript <1.8 has a busted parse of decorators (see bug for
   an example), so update to TS 1.8;
2) We stripped comments when emitting "private" to avoid a Closure
   issue but doing so also stripped preceding whitespace, which
   meant that in a line like "@foo private bar" there would be no
   space between "@foo" and "private" in the output.  Fix this by
   being more careful about emitting whitespace.

Fixes #35.