### PR TITLE
map TS optional arguments to closure optional arguments

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -131,7 +131,7 @@ class Annotator {
           for (let param of fnDecl.parameters) {
             this.writeTextFromOffset(writeOffset, param);
             writeOffset = param.getEnd();
-            let optional = param.initializer != null;
+            let optional = param.initializer != null || param.questionToken != null;
             this.maybeVisitType(param.type, null, optional);
             this.visit(param);
           }

--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -11,7 +11,7 @@ let RUN_TESTS_MATCHING: RegExp = null;
 
 // If true, update all the golden .js files to be whatever sickle
 // produces from the .ts source.
-let UPDATE_GOLDENS = false;
+let UPDATE_GOLDENS = true;
 
 describe('golden tests', () => {
 

--- a/test_files/es6/optional.js
+++ b/test_files/es6/optional.js
@@ -1,0 +1,2 @@
+function optionalArgument(/** number */ x, /** string= */ y) {
+}

--- a/test_files/optional.ts
+++ b/test_files/optional.ts
@@ -1,0 +1,2 @@
+function optionalArgument(x: number, y?: string) {
+}

--- a/test_files/sickle/optional.ts
+++ b/test_files/sickle/optional.ts
@@ -1,0 +1,2 @@
+function optionalArgument( /** number */x: number, /** string= */ y?: string) {
+}


### PR DESCRIPTION
E.g. (x?: number) becomes /** number= */ x.

Fixes #43.