### PR TITLE
insert newlines into jsdoc comments when adding type annotations

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -196,7 +196,11 @@ class Annotator {
   }
 
   private visitProperty(p: ts.PropertyDeclaration | ts.ParameterDeclaration) {
-    this.maybeVisitType(p.type, this.existingClosureAnnotation(p) + '@type');
+    let existingAnnotation = this.existingClosureAnnotation(p).trim();
+    if (existingAnnotation) {
+      existingAnnotation += '\n';
+    }
+    this.maybeVisitType(p.type, existingAnnotation + '@type');
     this.emit('\nthis.');
     this.emit(p.name.getText());
     this.emit(';');

--- a/test_files/comments.ts
+++ b/test_files/comments.ts
@@ -1,8 +1,21 @@
-class A {
+class Comments {
   /** @export */
-  foo: string;
+  export1: string;
+  // Note: the below @export doesn't make it into the output because it
+  // it isn't in a JSDoc comment.
+  /// @export
+  export2: string;
   /* non js-doc comment */
-  bar: number;
+  nodoc1: number;
   // non js-doc comment
-  buz: number;
+  nodoc2: number;
+  /// non js-doc comment
+  nodoc3: number;
+  /** inline jsdoc comment without type annotation */
+  jsdoc1: number;
+  /**
+   * multi-line jsdoc comment without
+   * type annotation.
+   */
+  jsdoc2: number;
 }

--- a/test_files/es6/comments.js
+++ b/test_files/es6/comments.js
@@ -1,13 +1,25 @@
-class A {
+class Comments {
     // Sickle: begin synthetic ctor.
     constructor() {
         // Sickle: begin stub declarations.
-        /**  @export @type { string} */
-        this.foo;
+        /** @export
+       @type { string} */
+        this.export1;
+        /** @type { string} */
+        this.export2;
         /** @type { number} */
-        this.bar;
+        this.nodoc1;
         /** @type { number} */
-        this.buz;
+        this.nodoc2;
+        /** @type { number} */
+        this.nodoc3;
+        /** inline jsdoc comment without type annotation
+       @type { number} */
+        this.jsdoc1;
+        /** * multi-line jsdoc comment without
+          * type annotation.
+       @type { number} */
+        this.jsdoc2;
         // Sickle: end stub declarations.
     }
 }

--- a/test_files/es6/parameter_properties.js
+++ b/test_files/es6/parameter_properties.js
@@ -4,7 +4,8 @@ class ParamProps {
         // Sickle: begin stub declarations.
         this.bar = bar;
         this.bar2 = bar2;
-        /**  @export @type { string} */
+        /** @export
+       @type { string} */
         this.bar;
         /** @type { string} */
         this.bar2;

--- a/test_files/sickle/comments.ts
+++ b/test_files/sickle/comments.ts
@@ -1,22 +1,47 @@
-class A {
+class Comments {
   /** @export */
-  foo: string;
+  export1: string;
+  // Note: the below @export doesn't make it into the output because it
+  // it isn't in a JSDoc comment.
+  /// @export
+  export2: string;
   /* non js-doc comment */
-  bar: number;
+  nodoc1: number;
   // non js-doc comment
-  buz: number;
+  nodoc2: number;
+  /// non js-doc comment
+  nodoc3: number;
+  /** inline jsdoc comment without type annotation */
+  jsdoc1: number;
+  /**
+   * multi-line jsdoc comment without
+   * type annotation.
+   */
+  jsdoc2: number;
 // Sickle: begin synthetic ctor.
 constructor() {
 
 
 // Sickle: begin stub declarations.
 
- /**  @export @type { string} */
-this.foo;
+ /** @export
+@type { string} */
+this.export1;
+ /** @type { string} */
+this.export2;
  /** @type { number} */
-this.bar;
+this.nodoc1;
  /** @type { number} */
-this.buz;
+this.nodoc2;
+ /** @type { number} */
+this.nodoc3;
+ /** inline jsdoc comment without type annotation
+@type { number} */
+this.jsdoc1;
+ /** * multi-line jsdoc comment without
+   * type annotation.
+@type { number} */
+this.jsdoc2;
 // Sickle: end stub declarations.
 }
 

--- a/test_files/sickle/parameter_properties.ts
+++ b/test_files/sickle/parameter_properties.ts
@@ -6,7 +6,8 @@ public bar2: string) {
 
 // Sickle: begin stub declarations.
 
- /**  @export @type { string} */
+ /** @export
+@type { string} */
 this.bar;
  /** @type { string} */
 this.bar2;


### PR DESCRIPTION
Also be more careful about spotting comments that are jsdoc comments.
Extend the comments test to include more variations of the forms of
jsdoc comments.

Fixes #22.