### PR TITLE
don't emit for ambient module declarations

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -72,6 +72,17 @@ class Annotator {
     // this.logWithIndent('node: ' + (<any>ts).SyntaxKind[node.kind]);
     this.indent++;
     switch (node.kind) {
+      case ts.SyntaxKind.ModuleDeclaration:
+        if (node.flags & ts.NodeFlags.Ambient) {
+          // An ambient module declaration only declares types for TypeScript's
+          // benefit, so we want to skip all Closure processing of it.
+          this.writeRange(node.getFullStart(), node.getEnd());
+          break;
+        } else {
+          // Process this node like any other.
+          this.writeNode(node);
+        }
+        break;
       case ts.SyntaxKind.VariableDeclaration:
         this.maybeVisitType((<ts.VariableDeclaration>node).type);
         this.writeNode(node);

--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -7,7 +7,7 @@ import {SickleOptions} from '../src/sickle';
 import {annotateSource, transformSource, goldenTests} from './test_support';
 
 let RUN_TESTS_MATCHING: RegExp = null;
-// RUN_TESTS_MATCHING = /fields/;
+RUN_TESTS_MATCHING = /declare/;
 
 // If true, update all the golden .js files to be whatever sickle
 // produces from the .ts source.

--- a/test_files/declare.ts
+++ b/test_files/declare.ts
@@ -1,0 +1,14 @@
+declare module DeclareTest {
+  // This enum should not cause any extra sickle statements to be
+  // emitted, because it is contained within a "declare" block.
+  enum FileType {
+    VALID = 1,
+  }
+}
+
+module DeclareTestIncluded {
+  // This enum should produce statements, as it's not a "declare".
+  enum FileType {
+    VALID = 1,
+  }
+}

--- a/test_files/es6/declare.js
+++ b/test_files/es6/declare.js
@@ -1,0 +1,10 @@
+var DeclareTestIncluded;
+(function (DeclareTestIncluded) {
+    // This enum should produce statements, as it's not a "declare".
+    var FileType;
+    (function (FileType) {
+        FileType[FileType["VALID"] = 1] = "VALID";
+    })(FileType || (FileType = {}));
+    /** @type {FileType} */
+    FileType.VALID = 1;
+})(DeclareTestIncluded || (DeclareTestIncluded = {}));

--- a/test_files/sickle/declare.ts
+++ b/test_files/sickle/declare.ts
@@ -1,0 +1,18 @@
+declare module DeclareTest {
+  // This enum should not cause any extra sickle statements to be
+  // emitted, because it is contained within a "declare" block.
+  enum FileType {
+    VALID = 1,
+  }
+}
+
+module DeclareTestIncluded {/** @typedef {number} */
+
+  // This enum should produce statements, as it's not a "declare".
+  enum FileType {
+    VALID = 1,
+  }
+/** @type {FileType} */
+(<any>FileType).VALID =  1;
+
+}


### PR DESCRIPTION
Skip over the contents of a "declare module ...", as it's only
making declaraitons for TypeScript's (not Closure's) benefit.