### PR TITLE
skip comments when exporting enums

### DIFF
--- a/test_files/es6/enum.js
+++ b/test_files/es6/enum.js
@@ -9,7 +9,6 @@ EnumTest1.XYZ = 0;
 /** @type {EnumTest1} */
 EnumTest1.PI = 3.14159;
 /** @typedef {number} */
-// This additional exported enum is here to exercise the fix for issue #51.
 export var EnumTest2;
 (function (EnumTest2) {
     EnumTest2[EnumTest2["XYZ"] = 0] = "XYZ";

--- a/test_files/sickle/enum.ts
+++ b/test_files/sickle/enum.ts
@@ -6,8 +6,6 @@ enum EnumTest1 {XYZ, PI = 3.14159}
 (<any>EnumTest1).PI =  3.14159;
 /** @typedef {number} */
 
-
-// This additional exported enum is here to exercise the fix for issue #51.
 export enum EnumTest2 {XYZ, PI = 3.14159}
 /** @type {EnumTest2} */
 (<any>EnumTest2).XYZ = 0;

--- a/test_files/sickle/parameter_properties.ts
+++ b/test_files/sickle/parameter_properties.ts
@@ -1,7 +1,6 @@
 class ParamProps {
   // The @export below should not show up in the output ctor.
-  constructor(
-public bar: string,
+  constructor( public bar: string,
 public bar2: string) {
 
 // Sickle: begin stub declarations.


### PR DESCRIPTION
When we export an enum we try to prepend an @typedef on it.
If the enum already had a comment on it, the comment interferes
with the type annotation.  Fix this by stripping comments when
emitting enums.  See the diff of es6/enum.js to see where this
is necessary.

This comment stripping is pretty hacky and will likely fail in
complex scenarios.  Right now it's limited to enums so maybe it
will work out?

See issue #52 for an example of why we can't do something obvious
to skip the comment -- the parse tree is pretty complex.