### PR TITLE
emit full jsdoc for function types

### DIFF
--- a/test_files/es6/arrow_fn.js
+++ b/test_files/es6/arrow_fn.js
@@ -1,1 +1,10 @@
-var fn3 = (/** number */ a) => 12;
+var fn3 = 
+/**
+ * @param { number} a
+ * @return { number}
+ */
+/**
+ * @param { number} a
+ * @return { number}
+ */
+    (a) => 12;

--- a/test_files/es6/basic.untyped.js
+++ b/test_files/es6/basic.untyped.js
@@ -1,6 +1,10 @@
-/** @return { ?} */ // This test is just a random collection of typed code, to
+// This test is just a random collection of typed code, to
 // ensure the output is all with {?} annotations.
-function func(/** ? */ arg1) {
+/**
+ * @param { ?} arg1
+ * @return { ?}
+ */
+function func(arg1) {
     return [3];
 }
 class Foo {

--- a/test_files/es6/decorator.js
+++ b/test_files/es6/decorator.js
@@ -7,7 +7,11 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __metadata = (this && this.__metadata) || function (k, v) {
     if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
 };
-function decorator(/** Object */ a, /** string */ b) { }
+/**
+ * @param { Object} a
+ * @param { string}  b
+ */
+function decorator(a, b) { }
 class DecoratorTest {
     // Sickle: begin synthetic ctor.
     constructor() {

--- a/test_files/es6/default.js
+++ b/test_files/es6/default.js
@@ -1,2 +1,6 @@
-function DefaultArgument(/** number */ x, /** string= */ y = 'hi') {
+/**
+ * @param { number} x
+ * @param { string=}  y
+ */
+function DefaultArgument(x, y = 'hi') {
 }

--- a/test_files/es6/file_comment.js
+++ b/test_files/es6/file_comment.js
@@ -1,4 +1,7 @@
-/** @return { string} */ // This test verifies that initial comments don't confuse offsets.
+// This test verifies that initial comments don't confuse offsets.
+/**
+ * @return { string}
+ */
 function foo() {
     return 'foo';
 }

--- a/test_files/es6/functions.js
+++ b/test_files/es6/functions.js
@@ -1,4 +1,12 @@
-/** @return { string} */ function fn1(/** number */ a) {
+/**
+ * @param { number} a
+ * @return { string}
+ */
+function fn1(a) {
     return "a";
 }
-function fn2(/** number */ a, /** number */ b) { }
+/**
+ * @param { number} a
+ * @param { number}  b
+ */
+function fn2(a, b) { }

--- a/test_files/es6/optional.js
+++ b/test_files/es6/optional.js
@@ -1,2 +1,7 @@
-function optionalArgument(/** number */ x, /** string= */ y) {
+/**
+ * @param { number} x
+ * @param { string=}  y
+ */
+function optionalArgument(x, y) {
 }
+optionalArgument(1);

--- a/test_files/optional.ts
+++ b/test_files/optional.ts
@@ -1,2 +1,3 @@
 function optionalArgument(x: number, y?: string) {
 }
+optionalArgument(1);

--- a/test_files/sickle/arrow_fn.ts
+++ b/test_files/sickle/arrow_fn.ts
@@ -1,1 +1,6 @@
-var fn3 = /** @return { number} */ ( /** number */a: number): number => 12;
+var fn3 = 
+/**
+ * @param { number} a
+ * @return { number}
+ */
+(a: number): number => 12;

--- a/test_files/sickle/basic.untyped.ts
+++ b/test_files/sickle/basic.untyped.ts
@@ -1,6 +1,11 @@
- /** @return { ?} */// This test is just a random collection of typed code, to
+// This test is just a random collection of typed code, to
 // ensure the output is all with {?} annotations.
-function func( /** ? */arg1: string): number[] {
+
+/**
+ * @param { ?} arg1
+ * @return { ?}
+ */
+function func(arg1: string): number[] {
   return [3];
 }
 

--- a/test_files/sickle/decorator.ts
+++ b/test_files/sickle/decorator.ts
@@ -1,4 +1,9 @@
-function decorator( /** Object */a: Object, /** string */ b: string) {}
+
+/**
+ * @param { Object} a
+ * @param { string}  b
+ */
+function decorator(a: Object, b: string) {}
 
 class DecoratorTest {
   @decorator

--- a/test_files/sickle/default.ts
+++ b/test_files/sickle/default.ts
@@ -1,2 +1,7 @@
-function DefaultArgument( /** number */x: number, /** string= */ y: string = 'hi') {
+
+/**
+ * @param { number} x
+ * @param { string=}  y
+ */
+function DefaultArgument(x: number, y: string = 'hi') {
 }

--- a/test_files/sickle/file_comment.ts
+++ b/test_files/sickle/file_comment.ts
@@ -1,4 +1,8 @@
- /** @return { string} */// This test verifies that initial comments don't confuse offsets.
+// This test verifies that initial comments don't confuse offsets.
+
+/**
+ * @return { string}
+ */
 function foo(): string {
   return 'foo';
 }

--- a/test_files/sickle/functions.ts
+++ b/test_files/sickle/functions.ts
@@ -1,4 +1,14 @@
- /** @return { string} */function fn1( /** number */a: number): string {
+
+/**
+ * @param { number} a
+ * @return { string}
+ */
+function fn1(a: number): string {
   return "a";
 }
-function fn2( /** number */a: number, /** number */ b: number) {}
+
+/**
+ * @param { number} a
+ * @param { number}  b
+ */
+function fn2(a: number, b: number) {}

--- a/test_files/sickle/optional.ts
+++ b/test_files/sickle/optional.ts
@@ -1,2 +1,8 @@
-function optionalArgument( /** number */x: number, /** string= */ y?: string) {
+
+/**
+ * @param { number} x
+ * @param { string=}  y
+ */
+function optionalArgument(x: number, y?: string) {
 }
+optionalArgument(1);


### PR DESCRIPTION
Rather than emitting a type per parameter, emit a jsdoc
before the function declaration.  This allows us to mark optional
arguments properly with the = suffix.  Note the changed "optional.ts"
test; it now verifies that Closure accepts a missing argument when
that argument was missing before.

Fixes #43.