### PR TITLE
update jscompiler test timeout to 20 seconds

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -81,7 +81,7 @@ gulp.task('test.e2e', ['test.compile'], function(done) {
     done();
     return;
   }
-  return gulp.src(['build/test/**/e2e*.js']).pipe(mocha({timeout: 10000}));
+  return gulp.src(['build/test/**/e2e*.js']).pipe(mocha({timeout: 20000}));
 });
 
 gulp.task('test', ['test.unit', 'test.e2e', 'test.check-format']);


### PR DESCRIPTION
We're now hitting the 10 second timeout on Travis.
Ugly workaround: wait up to 20 seconds.