### PR TITLE
preserve closure annotations when emitting functions

### DIFF
--- a/test_files/es6/basic.untyped.js
+++ b/test_files/es6/basic.untyped.js
@@ -1,5 +1,3 @@
-// This test is just a random collection of typed code, to
-// ensure the output is all with {?} annotations.
 /**
  * @param { ?} arg1
  * @return { ?}

--- a/test_files/es6/file_comment.js
+++ b/test_files/es6/file_comment.js
@@ -1,4 +1,3 @@
-// This test verifies that initial comments don't confuse offsets.
 /**
  * @return { string}
  */

--- a/test_files/es6/functions.js
+++ b/test_files/es6/functions.js
@@ -2,11 +2,17 @@
  * @param { number} a
  * @return { string}
  */
-function fn1(a) {
+function FunctionsTest1(a) {
     return "a";
 }
 /**
  * @param { number} a
  * @param { number}  b
  */
-function fn2(a, b) { }
+function FunctionsTest2(a, b) { }
+/**
+ * @ngInject
+ * @param { number} a
+ * @param { number}  b
+ */
+function FunctionsTest3(a, b) { }

--- a/test_files/functions.ts
+++ b/test_files/functions.ts
@@ -1,4 +1,6 @@
-function fn1(a: number): string {
+function FunctionsTest1(a: number): string {
   return "a";
 }
-function fn2(a: number, b: number) {}
+function FunctionsTest2(a: number, b: number) {}
+/** @ngInject */
+function FunctionsTest3(a: number, b: number) {}

--- a/test_files/sickle/arrow_fn.ts
+++ b/test_files/sickle/arrow_fn.ts
@@ -1,4 +1,4 @@
-var fn3 = 
+var fn3 =
 /**
  * @param { number} a
  * @return { number}

--- a/test_files/sickle/basic.untyped.ts
+++ b/test_files/sickle/basic.untyped.ts
@@ -1,5 +1,3 @@
-// This test is just a random collection of typed code, to
-// ensure the output is all with {?} annotations.
 
 /**
  * @param { ?} arg1

--- a/test_files/sickle/file_comment.ts
+++ b/test_files/sickle/file_comment.ts
@@ -1,4 +1,3 @@
-// This test verifies that initial comments don't confuse offsets.
 
 /**
  * @return { string}

--- a/test_files/sickle/functions.ts
+++ b/test_files/sickle/functions.ts
@@ -3,12 +3,17 @@
  * @param { number} a
  * @return { string}
  */
-function fn1(a: number): string {
+function FunctionsTest1(a: number): string {
   return "a";
 }
-
 /**
  * @param { number} a
  * @param { number}  b
  */
-function fn2(a: number, b: number) {}
+function FunctionsTest2(a: number, b: number) {}
+/**
+ * @ngInject
+ * @param { number} a
+ * @param { number}  b
+ */
+function FunctionsTest3(a: number, b: number) {}


### PR DESCRIPTION
The change in 16a0f692312006e68a515d000389e80a08f4a7e1 caused
us to emit a JSDoc comment before functions, which means we
would drop any already existing JSDoc comment.

Fix this by merging existing JSDocs with our new comment.
Add a test in functions.ts to cover this.  (The other changed
tests are just due to changing comment emits.)