### PR TITLE
don't crash on function overloads

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -131,6 +131,15 @@ class Annotator {
       // Otherwise, fall through to the shared processing for function.
       case ts.SyntaxKind.FunctionDeclaration:
         let fnDecl = <ts.FunctionLikeDeclaration>node;
+
+        if (!fnDecl.body) {
+          // Functions are allowed to not have bodies in the presence
+          // of overloads.  It's not clear how to translate these overloads
+          // into Closure types, so skip them for now.
+          this.writeNode(node);
+          break;
+        }
+
         // The first \n makes the output sometimes uglier than necessary,
         // but it's needed to work around
         // https://github.com/Microsoft/TypeScript/issues/6982

--- a/test_files/functions.in.ts
+++ b/test_files/functions.in.ts
@@ -1,3 +1,4 @@
+function FunctionsTest1(a: any): string;
 function FunctionsTest1(a: number): string {
   return "a";
 }

--- a/test_files/functions.sickle.ts
+++ b/test_files/functions.sickle.ts
@@ -1,4 +1,4 @@
-
+function FunctionsTest1(a: any): string;
 /**
  * @param { number} a
  * @return { string}


### PR DESCRIPTION
Function overloads are written as function declarations with
empty bodies, so check that the body is present before emitting.