### PR TITLE
don't drop typescript type assertion

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -197,7 +197,7 @@ class Annotator {
         let typeAssertion = <ts.TypeAssertion>node;
         this.maybeEmitJSDocType(typeAssertion.type);
         this.emit('(');
-        this.visit(typeAssertion.expression);
+        this.writeNode(node);
         this.emit(')');
         break;
       default:

--- a/test_files/coerce.sickle.ts
+++ b/test_files/coerce.sickle.ts
@@ -1,1 +1,1 @@
-let x = 'hello, ' + /**string */(JSON.parse('"world"'));
+let x = 'hello, ' + /**string */( <string>JSON.parse('"world"'));

--- a/test_files/coerce.tr.js
+++ b/test_files/coerce.tr.js
@@ -1,1 +1,1 @@
-let x = 'hello, ' + (JSON.parse('"world"'));
+let x = 'hello, ' + JSON.parse('"world"');


### PR DESCRIPTION
When translating, e.g.
  <string>foo
we need to emit both the Closure *and* the TS type, e.g.
  /** string */(<string>foo)

My previous change was only emitting the Closure one.