### PR TITLE
skip processing of ambient modules

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -85,6 +85,16 @@ class Annotator {
     // this.logWithIndent('node: ' + (<any>ts).SyntaxKind[node.kind]);
     this.indent++;
     switch (node.kind) {
+      case ts.SyntaxKind.ModuleDeclaration:
+        if (node.flags & ts.NodeFlags.Ambient) {
+          // An ambient module declaration only declares types for TypeScript's
+          // benefit, so we want to skip all Sickle processing of it.
+          this.writeRange(node.getFullStart(), node.getEnd());
+          break;
+        } else {
+          this.writeNode(node);
+        }
+        break;
       case ts.SyntaxKind.VariableDeclaration:
         this.maybeEmitJSDocType((<ts.VariableDeclaration>node).type);
         this.writeNode(node);

--- a/test_files/declare.in.ts
+++ b/test_files/declare.in.ts
@@ -1,0 +1,5 @@
+declare module DeclareTest {
+  export class Foo {
+    constructor();
+  }
+}

--- a/test_files/declare.sickle.ts
+++ b/test_files/declare.sickle.ts
@@ -1,0 +1,5 @@
+declare module DeclareTest {
+  export class Foo {
+    constructor();
+  }
+}


### PR DESCRIPTION
Ambient modules contain declarations of external values,
and aren't of interest to sickle.  Skipping them means we
don't need to worry about e.g. a declared constructor that
has no body.

Works around issue #74.