### PR TITLE
translate "declare interface" as "@export all fields"

### DIFF
--- a/test_files/basic.untyped.sickle.ts
+++ b/test_files/basic.untyped.sickle.ts
@@ -18,9 +18,9 @@ constructor(private ctorArg: string) {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { ?} */
-    Foo.prototype.field;
+Foo.prototype.field;
  /** @type { ?} */
-    Foo.prototype.ctorArg;
+Foo.prototype.ctorArg;
   }
 
 }

--- a/test_files/comments.sickle.ts
+++ b/test_files/comments.sickle.ts
@@ -22,22 +22,22 @@ class Comments {
   static _sickle_typeAnnotationsHelper() {
  /** @export
 @type { string} */
-    Comments.prototype.export1;
+Comments.prototype.export1;
  /** @type { string} */
-    Comments.prototype.export2;
+Comments.prototype.export2;
  /** @type { number} */
-    Comments.prototype.nodoc1;
+Comments.prototype.nodoc1;
  /** @type { number} */
-    Comments.prototype.nodoc2;
+Comments.prototype.nodoc2;
  /** @type { number} */
-    Comments.prototype.nodoc3;
+Comments.prototype.nodoc3;
  /** inline jsdoc comment without type annotation
 @type { number} */
-    Comments.prototype.jsdoc1;
+Comments.prototype.jsdoc1;
  /** * multi-line jsdoc comment without
    * type annotation.
 @type { number} */
-    Comments.prototype.jsdoc2;
+Comments.prototype.jsdoc2;
   }
 
 }

--- a/test_files/declare.in.ts
+++ b/test_files/declare.in.ts
@@ -1,5 +1,9 @@
-declare module DeclareTest {
+declare module DeclareTestModule {
   export class Foo {
     constructor();
   }
+}
+
+declare interface DeclareTestInterface {
+  foo: string;
 }

--- a/test_files/declare.sickle.ts
+++ b/test_files/declare.sickle.ts
@@ -1,5 +1,15 @@
-declare module DeclareTest {
+declare module DeclareTestModule {
   export class Foo {
     constructor();
   }
 }
+
+declare interface DeclareTestInterface {
+  foo: string;
+}
+/** @record @struct */
+function DeclareTestInterface() {}
+ /** @export
+@type { string} */
+DeclareTestInterface.prototype.foo;
+

--- a/test_files/declare.tr.js
+++ b/test_files/declare.tr.js
@@ -1,0 +1,5 @@
+/** @record @struct */
+function DeclareTestInterface() { }
+/** @export
+@type { string} */
+DeclareTestInterface.prototype.foo;

--- a/test_files/decorator.sickle.ts
+++ b/test_files/decorator.sickle.ts
@@ -11,7 +11,7 @@ private x: number;
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { number} */
-    DecoratorTest.prototype.x;
+DecoratorTest.prototype.x;
   }
 
 }

--- a/test_files/fields.sickle.ts
+++ b/test_files/fields.sickle.ts
@@ -16,11 +16,11 @@ getF1() {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { string} */
-    FieldsTest.prototype.field1;
+FieldsTest.prototype.field1;
  /** @type { number} */
-    FieldsTest.prototype.field2;
+FieldsTest.prototype.field2;
  /** @type { number} */
-    FieldsTest.prototype.field3;
+FieldsTest.prototype.field3;
   }
 
 }

--- a/test_files/fields_no_ctor.sickle.ts
+++ b/test_files/fields_no_ctor.sickle.ts
@@ -3,7 +3,7 @@ class NoCtor {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { number} */
-    NoCtor.prototype.field1;
+NoCtor.prototype.field1;
   }
 
 }

--- a/test_files/parameter_properties.sickle.ts
+++ b/test_files/parameter_properties.sickle.ts
@@ -10,9 +10,9 @@ public bar2: string) {}
   static _sickle_typeAnnotationsHelper() {
  /** @export
 @type { string} */
-    ParamProps.prototype.bar;
+ParamProps.prototype.bar;
  /** @type { string} */
-    ParamProps.prototype.bar2;
+ParamProps.prototype.bar2;
   }
 
 }

--- a/test_files/structural.untyped.sickle.ts
+++ b/test_files/structural.untyped.sickle.ts
@@ -9,7 +9,7 @@ method(): string { return this.field1; }
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { ?} */
-    StructuralTest.prototype.field1;
+StructuralTest.prototype.field1;
   }
 
 }

--- a/test_files/super.sickle.ts
+++ b/test_files/super.sickle.ts
@@ -12,7 +12,7 @@ constructor(public x: number) {}
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { number} */
-    SuperTestBaseOneArg.prototype.x;
+SuperTestBaseOneArg.prototype.x;
   }
 
 }
@@ -28,7 +28,7 @@ constructor(public y: string) {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { string} */
-    SuperTestDerivedParamProps.prototype.y;
+SuperTestDerivedParamProps.prototype.y;
   }
 
 }
@@ -44,7 +44,7 @@ constructor() {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { string} */
-    SuperTestDerivedInitializedProps.prototype.y;
+SuperTestDerivedInitializedProps.prototype.y;
   }
 
 }
@@ -79,7 +79,7 @@ class SuperTestDerivedInterface implements SuperTestInterface {
 
   static _sickle_typeAnnotationsHelper() {
  /** @type { number} */
-    SuperTestDerivedInterface.prototype.foo;
+SuperTestDerivedInterface.prototype.foo;
   }
 
 }


### PR DESCRIPTION
To do so, refactor the annotations helper logic so that
it can be used from multiple places where the fields have
lots of different incompatible types.