### PR TITLE
parse jsdoc to handle @param/@return properly

### DIFF
--- a/test_files/basic.untyped.sickle.ts
+++ b/test_files/basic.untyped.sickle.ts
@@ -10,7 +10,7 @@ function func(arg1: string): number[] {
 class Foo {
   field: string;
 /**
- * @param { ?}  ctorArg
+ * @param { ?} ctorArg
  */
 constructor(private ctorArg: string) {
     this.field = 'hello';

--- a/test_files/basic.untyped.tr.js
+++ b/test_files/basic.untyped.tr.js
@@ -7,7 +7,7 @@ function func(arg1) {
 }
 class Foo {
     /**
-     * @param { ?}  ctorArg
+     * @param { ?} ctorArg
      */
     constructor(ctorArg) {
         this.ctorArg = ctorArg;

--- a/test_files/comments.sickle.ts
+++ b/test_files/comments.sickle.ts
@@ -34,8 +34,7 @@ class Comments {
  /** inline jsdoc comment without type annotation
 @type { number} */
     Comments.prototype.jsdoc1;
- /** * multi-line jsdoc comment without
-   * type annotation.
+ /** multi-line jsdoc comment without type annotation.
 @type { number} */
     Comments.prototype.jsdoc2;
   }

--- a/test_files/comments.tr.js
+++ b/test_files/comments.tr.js
@@ -14,8 +14,7 @@ class Comments {
         /** inline jsdoc comment without type annotation
        @type { number} */
         Comments.prototype.jsdoc1;
-        /** * multi-line jsdoc comment without
-          * type annotation.
+        /** multi-line jsdoc comment without type annotation.
        @type { number} */
         Comments.prototype.jsdoc2;
     }

--- a/test_files/decorator.sickle.ts
+++ b/test_files/decorator.sickle.ts
@@ -1,7 +1,7 @@
 
 /**
  * @param { Object} a
- * @param { string}  b
+ * @param { string} b
  */
 function decorator(a: Object, b: string) {}
 

--- a/test_files/decorator.tr.js
+++ b/test_files/decorator.tr.js
@@ -9,7 +9,7 @@ var __metadata = (this && this.__metadata) || function (k, v) {
 };
 /**
  * @param { Object} a
- * @param { string}  b
+ * @param { string} b
  */
 function decorator(a, b) { }
 class DecoratorTest {

--- a/test_files/default.sickle.ts
+++ b/test_files/default.sickle.ts
@@ -1,7 +1,7 @@
 
 /**
  * @param { number} x
- * @param { string=}  y
+ * @param { string=} y
  */
 function DefaultArgument(x: number, y: string = 'hi') {
 }

--- a/test_files/default.tr.js
+++ b/test_files/default.tr.js
@@ -1,6 +1,6 @@
 /**
  * @param { number} x
- * @param { string=}  y
+ * @param { string=} y
  */
 function DefaultArgument(x, y = 'hi') {
 }

--- a/test_files/fields.sickle.ts
+++ b/test_files/fields.sickle.ts
@@ -2,7 +2,7 @@ class FieldsTest {
   field1: string;
   field2: number;
 /**
- * @param { number}  field3
+ * @param { number} field3
  */
 constructor(private field3: number) {
     this.field3 = 2 + 1;

--- a/test_files/fields.tr.js
+++ b/test_files/fields.tr.js
@@ -1,6 +1,6 @@
 class FieldsTest {
     /**
-     * @param { number}  field3
+     * @param { number} field3
      */
     constructor(field3) {
         this.field3 = field3;

--- a/test_files/functions.sickle.ts
+++ b/test_files/functions.sickle.ts
@@ -8,12 +8,12 @@ function FunctionsTest1(a: number): string {
 }
 /**
  * @param { number} a
- * @param { number}  b
+ * @param { number} b
  */
 function FunctionsTest2(a: number, b: number) {}
 /**
  * @ngInject
  * @param { number} a
- * @param { number}  b
+ * @param { number} b
  */
 function FunctionsTest3(a: number, b: number) {}

--- a/test_files/functions.tr.js
+++ b/test_files/functions.tr.js
@@ -7,12 +7,12 @@ function FunctionsTest1(a) {
 }
 /**
  * @param { number} a
- * @param { number}  b
+ * @param { number} b
  */
 function FunctionsTest2(a, b) { }
 /**
  * @ngInject
  * @param { number} a
- * @param { number}  b
+ * @param { number} b
  */
 function FunctionsTest3(a, b) { }

--- a/test_files/jsdoc.in.ts
+++ b/test_files/jsdoc.in.ts
@@ -1,0 +1,14 @@
+/**
+ * @param foo a string.
+ * @return return comment.
+ */
+function jsDocTestFunction(foo: string, baz: string): string {
+  return foo;
+}
+
+class JSDocTest {
+  /** @export */
+  exported: string;
+
+  ordinaryString: string;
+}

--- a/test_files/jsdoc.sickle.ts
+++ b/test_files/jsdoc.sickle.ts
@@ -1,0 +1,25 @@
+
+/**
+ * @param { string} foo a string.
+ * @param { string} baz
+ * @return { string} return comment.
+ */
+function jsDocTestFunction(foo: string, baz: string): string {
+  return foo;
+}
+
+class JSDocTest {
+  /** @export */
+  exported: string;
+
+  ordinaryString: string;
+
+  static _sickle_typeAnnotationsHelper() {
+ /** @export
+@type { string} */
+    JSDocTest.prototype.exported;
+ /** @type { string} */
+    JSDocTest.prototype.ordinaryString;
+  }
+
+}

--- a/test_files/jsdoc.tr.js
+++ b/test_files/jsdoc.tr.js
@@ -1,0 +1,17 @@
+/**
+ * @param { string} foo a string.
+ * @param { string} baz
+ * @return { string} return comment.
+ */
+function jsDocTestFunction(foo, baz) {
+    return foo;
+}
+class JSDocTest {
+    static _sickle_typeAnnotationsHelper() {
+        /** @export
+       @type { string} */
+        JSDocTest.prototype.exported;
+        /** @type { string} */
+        JSDocTest.prototype.ordinaryString;
+    }
+}

--- a/test_files/optional.sickle.ts
+++ b/test_files/optional.sickle.ts
@@ -1,7 +1,7 @@
 
 /**
  * @param { number} x
- * @param { string=}  y
+ * @param { string=} y
  */
 function optionalArgument(x: number, y?: string) {
 }
@@ -10,7 +10,7 @@ optionalArgument(1);
 class OptionalTest {
 /**
  * @param { string} a
- * @param { string=}  b
+ * @param { string=} b
  */
 constructor(a: string, b?: string) {}
 /**

--- a/test_files/optional.tr.js
+++ b/test_files/optional.tr.js
@@ -1,6 +1,6 @@
 /**
  * @param { number} x
- * @param { string=}  y
+ * @param { string=} y
  */
 function optionalArgument(x, y) {
 }
@@ -8,7 +8,7 @@ optionalArgument(1);
 class OptionalTest {
     /**
      * @param { string} a
-     * @param { string=}  b
+     * @param { string=} b
      */
     constructor(a, b) {
     }

--- a/test_files/parameter_properties.sickle.ts
+++ b/test_files/parameter_properties.sickle.ts
@@ -1,7 +1,7 @@
 class ParamProps {
 /**
- * @param { string}  bar
- * @param { string}  bar2
+ * @param { string} bar
+ * @param { string} bar2
  */
 constructor(
 public bar: string,

--- a/test_files/parameter_properties.tr.js
+++ b/test_files/parameter_properties.tr.js
@@ -1,7 +1,7 @@
 class ParamProps {
     /**
-     * @param { string}  bar
-     * @param { string}  bar2
+     * @param { string} bar
+     * @param { string} bar2
      */
     constructor(bar, bar2) {
         this.bar = bar;

--- a/test_files/super.sickle.ts
+++ b/test_files/super.sickle.ts
@@ -6,7 +6,7 @@ constructor() {}
 
 class SuperTestBaseOneArg {
 /**
- * @param { number}  x
+ * @param { number} x
  */
 constructor(public x: number) {}
 
@@ -20,7 +20,7 @@ constructor(public x: number) {}
 // A ctor with a parameter property.
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
 /**
- * @param { string}  y
+ * @param { string} y
  */
 constructor(public y: string) {
     super(3);

--- a/test_files/super.tr.js
+++ b/test_files/super.tr.js
@@ -6,7 +6,7 @@ class SuperTestBaseNoArg {
 }
 class SuperTestBaseOneArg {
     /**
-     * @param { number}  x
+     * @param { number} x
      */
     constructor(x) {
         this.x = x;
@@ -19,7 +19,7 @@ class SuperTestBaseOneArg {
 // A ctor with a parameter property.
 class SuperTestDerivedParamProps extends SuperTestBaseOneArg {
     /**
-     * @param { string}  y
+     * @param { string} y
      */
     constructor(y) {
         super(3);


### PR DESCRIPTION
When emitting a function, we want to preserve any JSDoc describing
the parameters but supply our own values for the types.

TypeScript has a JSDoc parser, but it's not exposed in a place
where we can use it.  So for now do a hacky regexp-based parse
of JSDoc.  The interfaces used here are pretty similar to the
TypeScript ones so if the API does expose them, it shouldn't be
too hard to adjust.

Fixes issue #67.