### PR TITLE
don't reject @suppress {checkTypes} annotations

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -68,7 +68,7 @@ export function getJSDocAnnotation(comment: string): JSDocComment {
     let match = line.match(/^@(\S+) *(.*)/);
     if (match) {
       let [_, tagName, text] = match;
-      if (text[0] == '{') {
+      if (['param', 'return', 'type'].indexOf(tagName) != -1 && text[0] == '{') {
         throw new Error('type annotations (using {...}) are not allowed');
       }
 

--- a/test/sickle_test.ts
+++ b/test/sickle_test.ts
@@ -116,4 +116,9 @@ describe('getJSDocAnnotation', () => {
     let source = `/** @type {string} foo */`;
     expect(() => getJSDocAnnotation(source)).to.throw(Error);
   });
+  it('allows @suppress annotations', () => {
+    let source = `/** @suppress {checkTypes} I hate types */`;
+    expect(getJSDocAnnotation(source))
+        .to.deep.equal({tags: [{tagName: 'suppress', text: '{checkTypes} I hate types'}]})
+  });
 });


### PR DESCRIPTION
Rather than always disallowing {} in JSDoc, disallow it in the
specific cases we know that we already handle.