### PR TITLE
gather diagnostics rather than throwing exceptions

### DIFF
--- a/test_files/jsdoc.in.ts
+++ b/test_files/jsdoc.in.ts
@@ -6,9 +6,17 @@ function jsDocTestFunction(foo: string, baz: string): string {
   return foo;
 }
 
+/**
+ * @param {badTypeHere} foo no types allowed.
+ */
+function jsDocTestBadDoc(foo: string) {}
+
 class JSDocTest {
   /** @export */
   exported: string;
 
-  ordinaryString: string;
+  stringWithoutJSDoc: string;
+
+  /** @type {badType} */
+  typedThing: number;
 }

--- a/test_files/jsdoc.sickle.ts
+++ b/test_files/jsdoc.sickle.ts
@@ -1,3 +1,6 @@
+Error at test_files/jsdoc.in.ts:9:1: type annotations (using {...}) are not allowed
+Error at test_files/jsdoc.in.ts:20:3: @type annotations are not allowed
+====
 
 /**
  * @param { string} foo a string.
@@ -7,19 +10,28 @@
 function jsDocTestFunction(foo: string, baz: string): string {
   return foo;
 }
+/**
+ * @param { string} foo
+ */
+function jsDocTestBadDoc(foo: string) {}
 
 class JSDocTest {
   /** @export */
   exported: string;
 
-  ordinaryString: string;
+  stringWithoutJSDoc: string;
+
+  /** @type {badType} */
+  typedThing: number;
 
   static _sickle_typeAnnotationsHelper() {
  /** @export
 @type { string} */
     JSDocTest.prototype.exported;
  /** @type { string} */
-    JSDocTest.prototype.ordinaryString;
+    JSDocTest.prototype.stringWithoutJSDoc;
+ /** @type { number} */
+    JSDocTest.prototype.typedThing;
   }
 
 }

--- a/test_files/jsdoc.tr.js
+++ b/test_files/jsdoc.tr.js
@@ -6,12 +6,18 @@
 function jsDocTestFunction(foo, baz) {
     return foo;
 }
+/**
+ * @param { string} foo
+ */
+function jsDocTestBadDoc(foo) { }
 class JSDocTest {
     static _sickle_typeAnnotationsHelper() {
         /** @export
        @type { string} */
         JSDocTest.prototype.exported;
         /** @type { string} */
-        JSDocTest.prototype.ordinaryString;
+        JSDocTest.prototype.stringWithoutJSDoc;
+        /** @type { number} */
+        JSDocTest.prototype.typedThing;
     }
 }


### PR DESCRIPTION
Produce an array of ts.Diagnostic, just like the compiler,
when encountering code we'd like the user to treat as invalid.
Keep this.fail() around for assertions.

Extend the test suite to dump the error messages in the golden
file so they can be reviewed.
