### PR TITLE
re-export each name from "export * from ..."

### DIFF
--- a/test_files/export.in.ts
+++ b/test_files/export.in.ts
@@ -1,0 +1,2 @@
+export * from './export_helper';
+export var localExport = 3;

--- a/test_files/export.sickle.ts
+++ b/test_files/export.sickle.ts
@@ -1,0 +1,2 @@
+export {foo,bar,baz} from './export_helper';
+export var localExport = 3;

--- a/test_files/export.tr.js
+++ b/test_files/export.tr.js
@@ -1,0 +1,2 @@
+export { foo, bar, baz } from './export_helper';
+export var localExport = 3;

--- a/test_files/export_helper.js
+++ b/test_files/export_helper.js
@@ -1,0 +1,7 @@
+export { baz } from './export_helper_2';
+export let foo = 3;
+export let bar = 3;
+// TODO(evanm): this interface causes a compilation error in Closure
+// due to sickle not yet transforming interfaces.
+// export interface Bar { barField: number; }
+// export var bar: Bar = null;

--- a/test_files/export_helper.sickle.ts
+++ b/test_files/export_helper.sickle.ts
@@ -1,0 +1,8 @@
+export {baz} from './export_helper_2';
+export let foo = 3;
+export let bar = 3;
+
+// TODO(evanm): this interface causes a compilation error in Closure
+// due to sickle not yet transforming interfaces.
+// export interface Bar { barField: number; }
+// export var bar: Bar = null;

--- a/test_files/export_helper.ts
+++ b/test_files/export_helper.ts
@@ -1,0 +1,10 @@
+// This file isn't itself a test case, but it is imported by the
+// export.in.ts test case.
+export * from './export_helper_2';
+export let foo = 3;
+export let bar = 3;
+
+// TODO(evanm): this interface causes a compilation error in Closure
+// due to sickle not yet transforming interfaces.
+// export interface Bar { barField: number; }
+// export var bar: Bar = null;

--- a/test_files/export_helper_2.js
+++ b/test_files/export_helper_2.js
@@ -1,0 +1,3 @@
+// This file isn't itself a test case, but it is imported by the
+// export.in.ts test case.
+export let baz = 3;

--- a/test_files/export_helper_2.sickle.ts
+++ b/test_files/export_helper_2.sickle.ts
@@ -1,0 +1,3 @@
+// This file isn't itself a test case, but it is imported by the
+// export.in.ts test case.
+export let baz = 3;

--- a/test_files/export_helper_2.ts
+++ b/test_files/export_helper_2.ts
@@ -1,0 +1,3 @@
+// This file isn't itself a test case, but it is imported by the
+// export.in.ts test case.
+export let baz = 3;


### PR DESCRIPTION
If we leave "export *" alone, TypeScript emits a for loop over
the exports of the re-exported module, but for Closure purposes
we want to instead emit the more verbose "exports.foo = module.foo"
for each exported symbol.

Fixes #47.