### PR TITLE
when converting export *, avoid local symbol names

### DIFF
--- a/test_files/export.in.ts
+++ b/test_files/export.in.ts
@@ -1,2 +1,5 @@
 export * from './export_helper';
+// This "foo" conflicts with a "foo" discovered via the above export,
+// so the above export's "foo" should not show up.
+export var foo: string = 'wins';
 export var localExport = 3;

--- a/test_files/export.sickle.ts
+++ b/test_files/export.sickle.ts
@@ -1,2 +1,5 @@
-export {foo,bar,baz} from './export_helper';
+export {bar,baz} from './export_helper';
+// This "foo" conflicts with a "foo" discovered via the above export,
+// so the above export's "foo" should not show up.
+export var /** string */ foo: string = 'wins';
 export var localExport = 3;

--- a/test_files/export.tr.js
+++ b/test_files/export.tr.js
@@ -1,2 +1,5 @@
-export { foo, bar, baz } from './export_helper';
+export { bar, baz } from './export_helper';
+// This "foo" conflicts with a "foo" discovered via the above export,
+// so the above export's "foo" should not show up.
+export var /** string */ foo = 'wins';
 export var localExport = 3;


### PR DESCRIPTION
We convert "export *" into "export {foo,bar,...}".
But if there's a locally exported symbol of the same name,
we shouldn't include it in the export list.

More work on #47.