### PR TITLE
when re-exporting *, don't avoid imports

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -285,10 +285,18 @@ class Annotator {
 
     // Gather the names of local exports, to avoid reexporting any
     // names that are already locally exported.
+    // To find symbols declared like
+    //   export {foo} from ...
+    // we must also query for "Alias", but that unfortunately also brings in
+    //   import {foo} from ...
+    // so the latter is filtered below.
     let locals =
         typeChecker.getSymbolsInScope(this.file, ts.SymbolFlags.Export | ts.SymbolFlags.Alias);
     let localSet: {[name: string]: boolean} = {};
     for (let local of locals) {
+      if (local.declarations.some(d => d.kind === ts.SyntaxKind.ImportSpecifier)) {
+        continue;
+      }
       localSet[local.name] = true;
     }
 

--- a/test_files/export.in.ts
+++ b/test_files/export.in.ts
@@ -13,3 +13,6 @@ export var exportLocal = 3;
 // it to the exports list.  export2 should only show up once in the
 // above two "export *" lines, though.
 let export2 = 3;
+
+// This is just an import, so export5 should still be included.
+import {export5} from './export_helper';

--- a/test_files/export.sickle.ts
+++ b/test_files/export.sickle.ts
@@ -1,4 +1,4 @@
-export {export2,export4} from './export_helper';
+export {export2,export5,export4} from './export_helper';
 export {} from './export_helper_2';
 
 // These conflict with an export discovered via the above exports,
@@ -13,3 +13,6 @@ export var exportLocal = 3;
 // it to the exports list.  export2 should only show up once in the
 // above two "export *" lines, though.
 let export2 = 3;
+
+// This is just an import, so export5 should still be included.
+import {export5} from './export_helper';

--- a/test_files/export.tr.js
+++ b/test_files/export.tr.js
@@ -1,4 +1,4 @@
-export { export2, export4 } from './export_helper';
+export { export2, export5, export4 } from './export_helper';
 // These conflict with an export discovered via the above exports,
 // so the above export's versions should not show up.
 export var /** string */ export1 = 'wins';

--- a/test_files/export_helper.js
+++ b/test_files/export_helper.js
@@ -7,3 +7,4 @@ export let export2 = 3;
 // due to sickle not yet transforming interfaces.
 // export interface Bar { barField: number; }
 // export var export3: Bar = null;
+export let export5 = 3;

--- a/test_files/export_helper.sickle.ts
+++ b/test_files/export_helper.sickle.ts
@@ -8,3 +8,5 @@ export let export2 = 3;
 // due to sickle not yet transforming interfaces.
 // export interface Bar { barField: number; }
 // export var export3: Bar = null;
+
+export let export5 = 3;

--- a/test_files/export_helper.ts
+++ b/test_files/export_helper.ts
@@ -8,3 +8,5 @@ export let export2 = 3;
 // due to sickle not yet transforming interfaces.
 // export interface Bar { barField: number; }
 // export var export3: Bar = null;
+
+export let export5 = 3;


### PR DESCRIPTION
The TypeScript API that let us retrieve aliased exports also
ended up retrieving aliased imports.  Avoid this by checking
the symbols we got.

More work on #47.