### PR TITLE
blacklist some variable names for closure externs

### DIFF
--- a/test_files/declare.in.ts
+++ b/test_files/declare.in.ts
@@ -17,3 +17,7 @@ declare var someGlobal: number;
 declare interface DeclareTestInterface {
   foo: string;
 }
+
+// Should be omitted from externs -- conflicts with Closure.
+declare var global: any;
+declare interface exports {}

--- a/test_files/declare.sickle.ts
+++ b/test_files/declare.sickle.ts
@@ -19,3 +19,7 @@ declare var someGlobal: number;
 declare interface DeclareTestInterface {
   foo: string;
 }
+
+// Should be omitted from externs -- conflicts with Closure.
+declare var global: any;
+declare interface exports {}


### PR DESCRIPTION
Don't create externs for variables that exist in Closure externs
already, such as "module" and "global".