### PR TITLE
fix(angular2): blacklist two more declare'd vars from angular2

### DIFF
--- a/src/sickle.ts
+++ b/src/sickle.ts
@@ -33,6 +33,8 @@ export let closureExternsBlacklist: string[] = [
   'exports',
   'global',
   'module',
+  'WorkerGlobalScope',
+  'Symbol',
 ];
 
 export function formatDiagnostics(diags: ts.Diagnostic[]): string {


### PR DESCRIPTION
I know, Phabricator.

I'm burning down a big list of hacks I had to add for angular2 to run, and would rather not take a detour into php-cli right now.