### PR TITLE
chore: disable the no-string-literal lint check

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -18,7 +18,6 @@
     "no-inferrable-types": true,
     "no-internal-module": true,
     "no-shadowed-variable": true,
-    "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unreachable": true,


### PR DESCRIPTION
It turns out it only syntactically checks object accesses, and is overly aggressive in doing so. Fixes #126.